### PR TITLE
Tweak `camelCase` vs. `snake_case` wording nitpick in `posts/2017-05-11-easy-json.md`

### DIFF
--- a/posts/2017-05-11-easy-json.md
+++ b/posts/2017-05-11-easy-json.md
@@ -122,7 +122,7 @@ BL.putStrLn $ encode indexResponse
 -- {"message":"Congrats!","status":"YOU_GOT_HERE_SO_OBVIOUSLY_SUCCESSFUL","metadata":{"app_version":9}}
 ```
 
-Note that the `appVersion` gets automatically converted to `camel_case` with the `camelTo2` option from
+Note that the `appVersion` field gets automatically converted from `camelCase` to `snake_case` with the `camelTo2` option from
 `Data.Aeson.Types`. Handy!
 
 We can check that encoding and decoding works, and use more type-safe lenses (in this case, `message`, which was


### PR DESCRIPTION
Hi Ben,

First of all, thanks for another helpful post about getting work done in Haskell.

Please forgive the nitpick, but something caught my eye while reading [Easily working with JSON](http://www.kovach.me/posts/2017-05-11-easy-json.html): towards the end you say,

> Note that the appVersion gets automatically converted to camel_case with the camelTo2 option from Data.Aeson.Types. Handy!

I think you must've meant "from `camelCase` to `snake_case`" though, right? Here's a tiny PR if you agree.

Thanks again for the posts!
Matt

[Wikipedia's snake_case explanation](https://en.wikipedia.org/wiki/Snake_case)


